### PR TITLE
Enable support for all OSes

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,23 +10,21 @@
 
   setMode('dark');
 
+  // Dynamically set during initialLoad event
   let builds = [];
   let build;
 
-  const runtimes = [
-    { value: 'flashplayer.exe', label: 'Flash Player' },
-    // { value: 'ruffle', label: 'Ruffle Player (Experimental)' }, TODO" implement this
-  ];
+  let runtimes = [];
+  let runtime;
 
-  let runtime = runtimes[0];
+  let current_game_version;
 
+  // Debug Variables
   let disabled = false;
   let showError = false;
   let errorCode = '';
 
   let debugLogs = [];
-
-  let version;
 
   EventsOn('infoLog', (event) => {
     debugLogs = [...debugLogs, event];
@@ -37,19 +35,31 @@
   }
 
   EventsOn('initialLoad', (event) => {
-    LogPrint(JSON.stringify(event));
+    // LogPrint(JSON.stringify(event));
 
+    // Dynamically gets the builds from JSON and set the first one as the default
     builds = Object.keys(event.manifest.builds).map((buildName) => ({
       value: buildName,
       label: capitalizeFirstLetter(buildName),
     }));
+
     build = builds[0];
-    version = event.manifest.currentGameVersion;
+
+    // Dynamically gets the flash runtimes from JSON and set the system one as default
+    runtimes = [{
+      value: event.manifest.flashRuntimes[event.platform],
+      label: `Flash Player (${capitalizeFirstLetter(event.platform)})`
+    }]
+
+    runtime = runtimes[0];
+
+    // Checks the JSON for the currentGameVersion
+    current_game_version = event.manifest.currentGameVersion;
 
     debugLogs = [
       ...debugLogs,
 
-      `Latest SWF version: ${event.manifest.currentGameVersion}`,
+      `Latest SWF version: ${current_game_version}`,
       `Latest Launcher version: ${event.manifest.currentLauncherVersion}`,
     ];
   });
@@ -60,7 +70,7 @@
 
   function launch() {
     disabled = true;
-    LaunchGame(build.value, version, runtime.value)
+    LaunchGame(build.value, current_game_version, runtime.value)
       .then(() => {
         showError = false;
         Quit();
@@ -90,7 +100,7 @@
     {/each}
   </div>
 
-  {#if !version}
+  {#if !current_game_version}
     <div role="status">
       <svg
         aria-hidden="true"

--- a/launcherScripts/linux_launcher.sh
+++ b/launcherScripts/linux_launcher.sh
@@ -1,0 +1,52 @@
+SWF_CHANNEL="bymr-stable"
+SWF_FILE="bymr-stable.swf"
+
+FLASHPLAYER_URL='https://archive.org/download/flashplayer32_0r0_363_win_sa/flashplayer32_0r0_363_linux_sa.x86_64.tar.gz'
+REQUEST_URL="https://api.github.com/repos/bym-refitted/backyard-monsters-refitted/releases/latest"
+DOWNLOAD_URL="https://github.com/bym-refitted/backyard-monsters-refitted/releases/download/"
+
+# Downloads Flash Player if its missing
+if [ ! -f "flashplayer" ] ; then
+    echo "Flash Player not found! Downloading Flash Player..."
+    
+    wget -O /tmp/flashplayer.tar.gz $FLASHPLAYER_URL
+    tar -xzf /tmp/flashplayer.tar.gz
+fi
+
+# Creates version file
+if [ ! -f "version" ]; then echo '0.0.0' > version
+fi
+
+# Fetches the latest SWF info
+# Caches the request in /tmp to prevent GitHub from getting mad
+echo "Checking for updates..."
+
+if [ ! -f "/tmp/bym_request_cache" ] ; then
+    curl --silent $REQUEST_URL > "/tmp/bym_request_cache"
+fi
+
+# Retrieves the download url from the request cache
+# Also removes double quotes using parameter expansion
+DOWNLOAD_URL=$(grep "browser_download_url.*" "/tmp/bym_request_cache" | grep bymr-stable)
+DOWNLOAD_URL=${DOWNLOAD_URL:3}
+DOWNLOAD_URL=${DOWNLOAD_URL//\"/}
+
+# Retrieves the Latest Version from the Url and compares it to the local version file
+# If the latest version is higher than the local one download it
+LATEST_VERSION=$(grep -oP '"tag_name":\s*"v\K[^"]+' "/tmp/bym_request_cache")
+LATEST_VERSION=${LATEST_VERSION:0:5}
+
+CURRENT_VERSION=$(cat version)
+
+if [[ $LATEST_VERSION > $CURRENT_VERSION ]]; then
+    echo "New SWF version found! Downloading..."
+    wget -O $SWF_FILE $DOWNLOAD_URL
+    echo $LATEST_VERSION > version
+
+else
+    echo "Game is up to date!"
+fi
+
+echo "Launching Game..."
+chmod +x flashplayer
+./flashplayer $SWF_FILE


### PR DESCRIPTION
- Code Cleanup
- Runtime was rewritten to use the API (This mean the launcher should support all OSes now)